### PR TITLE
docker-engine: Add a precision to the post-install message to make host network forwarding work

### DIFF
--- a/sysutils/docker-engine/pkg-message
+++ b/sysutils/docker-engine/pkg-message
@@ -15,6 +15,10 @@ nat-anchor "docker/*"
 rdr-anchor "docker/*"
 anchor "docker/*"
 
+The following addition to your rc.conf is also required to make NAT work:
+
+gateway_enable="YES"
+
 Dockerd will automatically enable nat for each bridge managed
 by it:
 


### PR DESCRIPTION
NAT doesn't seem to work otherwise

cc @gizahNL